### PR TITLE
[BUGFIX] Réparer le générateur firstname et lastname

### DIFF
--- a/generators/firstname.test.ts
+++ b/generators/firstname.test.ts
@@ -15,7 +15,7 @@ describe('Firstname Generator', () => {
         "civility": "Madame"
       }
     ]
-    const firstnames = [
+    const firstname = [
       {
         "value": "Nicolas",
         "gender": [
@@ -30,7 +30,7 @@ describe('Firstname Generator', () => {
       }
     ]
     // 1 % 3 = 1
-    const getFirstname = makeGetFirstname({ random: () => 1, data: { gender, firstnames }})
+    const getFirstname = makeGetFirstname({ random: () => 1, data: { gender, firstname }})
 
     const result = getFirstname({ gender: 'M' })
 

--- a/generators/firstname.ts
+++ b/generators/firstname.ts
@@ -2,8 +2,8 @@ import { type DataGenerator } from '../data-generator';
 
 export const makeGetFirstname: DataGenerator<[{ gender: string }], string> = ({ data, random }) => ({ gender }) => {
   const firstnames = gender
-    ? data.firstnames.filter((firstname: any) => firstname.gender.includes(gender))
-    : data.firstnames;
+    ? data.firstname.filter((firstname: any) => firstname.gender.includes(gender))
+    : data.firstname;
 
   return firstnames[random() % firstnames.length].value;
 }

--- a/generators/lastname.test.ts
+++ b/generators/lastname.test.ts
@@ -3,7 +3,7 @@ import {makeGetLastname} from './lastname'
 
 describe('Lastname Generator', () => {
   it('should return lastname', () => {
-    const lastnames = [
+    const lastname = [
       {
         "value": "Foo"
       },
@@ -14,7 +14,7 @@ describe('Lastname Generator', () => {
         "value": "Baz"
       }
     ]
-    const getLastname = makeGetLastname({random: () => 1, data: {lastnames}})
+    const getLastname = makeGetLastname({random: () => 1, data: {lastname}})
 
     const result = getLastname()
 

--- a/generators/lastname.ts
+++ b/generators/lastname.ts
@@ -1,5 +1,5 @@
 import { type DataGenerator } from '../data-generator';
 
 export const makeGetLastname: DataGenerator<[], string> = ({ data, random }) => () => {
-  return data.lastnames[random() % data.lastnames.length].value;
+  return data.lastname[random() % data.lastname.length].value;
 };

--- a/generators/person.test.ts
+++ b/generators/person.test.ts
@@ -15,7 +15,7 @@ describe('Person Generator', () => {
         "civility": "Madame"
       }
     ]
-    const firstnames = [
+    const firstname = [
       {
         "value": "Nicolas",
         "gender": [
@@ -29,7 +29,7 @@ describe('Person Generator', () => {
         ]
       }
     ]
-    const lastnames = [
+    const lastname = [
       {
         "value": "Foo"
       },
@@ -40,7 +40,7 @@ describe('Person Generator', () => {
         "value": "Baz"
       }
     ]
-    const getPerson = makeGetPerson({random: () => 1, data: { gender, lastnames, firstnames }})
+    const getPerson = makeGetPerson({random: () => 1, data: { gender, lastname, firstname }})
 
     const result = getPerson()
 


### PR DESCRIPTION
## :unicorn: Problème
Le générateur `firstname` nécessite actuellement des data sous la forme `firstnames` alors que les autres générateur sont au singulier.

## :robot: Proposition
Remplacer par `firstname` sans le s
## :rainbow: Remarques
<!-- Des infos supplémentaires, trucs et astuces ? -->

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
